### PR TITLE
[Feature] Open Feign을 위한 스쿼드 조회 시 선수 정보 반환 로직 개발

### DIFF
--- a/src/main/java/sejong/user/controller/UserSquadController.java
+++ b/src/main/java/sejong/user/controller/UserSquadController.java
@@ -1,0 +1,22 @@
+package sejong.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sejong.user.controller.res.UserSquadResponse;
+import sejong.user.service.UserSquadService;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/user-service")
+public class UserSquadController {
+    private final UserSquadService userSquadService;
+    @GetMapping("/users/{userId}/squad")
+    public ResponseEntity<UserSquadResponse> getUserInfoInSquad(@PathVariable(name = "userId") Long userId){
+        UserSquadResponse userSquadResponse = userSquadService.getUserInfoInSquad(userId);
+        return ResponseEntity.ok().body(userSquadResponse);
+    }
+}

--- a/src/main/java/sejong/user/controller/res/UserSquadResponse.java
+++ b/src/main/java/sejong/user/controller/res/UserSquadResponse.java
@@ -1,0 +1,10 @@
+package sejong.user.controller.res;
+
+import lombok.Builder;
+import lombok.Getter;
+@Getter
+@Builder
+public class UserSquadResponse {
+    private String name;
+    private String image;
+}

--- a/src/main/java/sejong/user/service/UserSquadService.java
+++ b/src/main/java/sejong/user/service/UserSquadService.java
@@ -1,0 +1,27 @@
+package sejong.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sejong.user.controller.res.UserSquadResponse;
+import sejong.user.entity.User;
+import sejong.user.global.exception.BadRequestException;
+import sejong.user.global.exception.constant.ExceptionMessageConstant;
+import sejong.user.repository.UserRepository;
+
+@RequiredArgsConstructor
+@Service
+public class UserSquadService {
+    private final UserRepository userRepository;
+    public UserSquadResponse getUserInfoInSquad(Long userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException(400,
+                        ExceptionMessageConstant.NOT_REGISTER_USER_EXCEPTION_MESSAGE));
+
+        UserSquadResponse userSquadResponse = UserSquadResponse.builder()
+                .name(user.getName())
+                .image(user.getImage())
+                .build();
+        return userSquadResponse;
+    }
+
+}


### PR DESCRIPTION
스쿼드 조회 시 유저의 name과 image가 필요하여, open feign을 위한 api 로직을 작성하였습니다.
team-service에서 feignclient로 api 사용 예정입니다.